### PR TITLE
only enable the necessary spaCy components - ~2x speedup

### DIFF
--- a/misaki/en.py
+++ b/misaki/en.py
@@ -433,7 +433,8 @@ class G2P:
         name = f"en_core_web_{'trf' if trf else 'sm'}"
         if not spacy.util.is_package(name):
             spacy.cli.download(name)
-        self.nlp = spacy.load(name)
+        components = ['transformer' if trf else 'tok2vec', 'tagger']
+        self.nlp = spacy.load(name, enable=components)
         self.lexicon = Lexicon(british)
         self.fallback = fallback if fallback else None
         self.unk = unk


### PR DESCRIPTION
the spacy nlp pipeline does a bunch of stuff that we don't need.

here's a silly benchmark:
```python
from doctest import pdb
text = pdb.__doc__
print(f'len(text): {len(text)}')
```
len(text): 12112

```python
import timeit
from misaki.en import G2P
g2p = G2P()
timeit.timeit('_ = g2p(text)', number=10, globals=dict(g2p=g2p, text=text))
```

before:
3.9930111920111813

after:
2.2777446639956906

great library, thanks for making it!