### PR TITLE
pyproject.toml: remove dependency on pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,6 @@ classifiers = [
 requires-python = ">=3.8, <3.13"
 dependencies = [
     "addict",
-    "pip>=25.0.1", 
-    # ^ Spacy needs pip within Python, uv lacks pip by default
     "regex",
 ]
 


### PR DESCRIPTION
The dependency on pip apparently comes via spacy, but spacy is only an optional dependency in some languages settings. Therefore, we don't need to require it for all installations. Pip is a large and unwieldy dependency, so better to avoid requiring all installations to install it.

There are no instances of pip being used within misaki itself: https://github.com/search?q=repo%3Ahexgrad%2Fmisaki%20pip&type=code