### PR TITLE
Enable Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.8, <3.13"
+requires-python = ">=3.8, <3.14"
 dependencies = [
     "addict",
     "pip>=25.0.1", 


### PR DESCRIPTION
Tested working with `kokoro -t Hello -o test.wav`. This is needed for Ubuntu 25.04.

See also: https://github.com/hexgrad/kokoro/pull/244