### PR TITLE
Don't use outdated pre-release spaCy 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-en = ["num2words", "spacy", "spacy-curated-transformers", "phonemizer-fork", "espeakng-loader", "torch", "transformers"]
+en = ["num2words", "spacy<4", "spacy-curated-transformers", "phonemizer-fork", "espeakng-loader", "torch", "transformers"]
 ja = ["fugashi", "jaconv", "mojimoji", "unidic", "pyopenjtalk"]
 ko = ["jamo", "nltk"]
 zh = ["jieba", "ordered-set", "pypinyin", "cn2an", "pypinyin-dict"]


### PR DESCRIPTION
spaCy 4 hasn't been released. 4.0.0.dev{1,2} have been yanked, questioning the stability. More importantly, 4.0.0.dev3 was published 2024-04-22 while the normal 3.8.7 is newer, being published 2025-05-23, a whole year later. The outdated 2024 spaCy depends on an outdated thinc, which depends on an outdated blis whose build fails on Python 3.13.

I fixed this by restricting spaCy to stable 3.x versions. The spaCy 4 apparently wasn't even being used in the final installation that Kokoro sees, somehow only appearing in a misconfigured build step.

Fixes: https://github.com/hexgrad/misaki/pull/85#issuecomment-3239248479
Reported-by: @cclauss