### PR TITLE
feat: Add offline mode support to FallbackNetwork

### DIFF
--- a/misaki/data/gb_gold.json
+++ b/misaki/data/gb_gold.json
@@ -66252,7 +66252,7 @@
     "DEFAULT": "ɹˈiːd",
     "VBD": "ɹˈɛd",
     "VBN": "ɹˈɛd",
-    "VBP": "ɹˈɛd"
+    "VBP": "ɹˈiːd"
   },
   "read's": "ɹˈiːdz",
   "read-in": "ɹˈiːdɪn",
@@ -68045,7 +68045,7 @@
     "NOUN": "ɹˈiːɹiːd",
     "VBD": "ɹiːɹˈɛd",
     "VBN": "ɹiːɹˈɛd",
-    "VBP": "ɹiːɹˈɛd"
+    "VBP": "ɹiːɹˈiːd"
   },
   "reread's": "ɹˈiːɹiːdz",
   "rereading": "ɹiːɹˈiːdɪŋ",
@@ -89069,7 +89069,7 @@
     "DEFAULT": "wˈuːnd",
     "VBD": "wˈWnd",
     "VBN": "wˈWnd",
-    "VBP": "wˈWnd"
+    "VBP": "wˈuːnd"
   },
   "wound's": "wˈuːndz",
   "wounded": "wˈuːndɪd",

--- a/misaki/data/us_gold.json
+++ b/misaki/data/us_gold.json
@@ -68102,7 +68102,7 @@
     "DEFAULT": "ɹˈid",
     "VBD": "ɹˈɛd",
     "VBN": "ɹˈɛd",
-    "VBP": "ɹˈɛd"
+    "VBP": "ɹˈid"
   },
   "read's": "ɹˈidz",
   "read-in": "ɹˈidˌɪn",
@@ -69997,7 +69997,7 @@
     "NOUN": "ɹˈiɹid",
     "VBD": "ɹiɹˈɛd",
     "VBN": "ɹiɹˈɛd",
-    "VBP": "ɹiɹˈɛd"
+    "VBP": "ɹˌiɹˈid"
   },
   "reread's": "ɹˈiɹidz",
   "rereading": "ɹˌiɹˈidɪŋ",
@@ -91908,7 +91908,7 @@
     "DEFAULT": "wˈund",
     "VBD": "wˈWnd",
     "VBN": "wˈWnd",
-    "VBP": "wˈWnd"
+    "VBP": "wˈund"
   },
   "wound's": "wˈundz",
   "wounded": "wˈundᵻd",

--- a/misaki/en.py
+++ b/misaki/en.py
@@ -26,7 +26,7 @@ def merge_tokens(tokens: List[MToken], unk: Optional[str] = None) -> MToken:
                 phonemes += ' '
             phonemes += unk if tk.phonemes is None else tk.phonemes
     return MToken(
-        text=''.join(tk.text + tk.whitespace for tk in tokens[:-1]) + tokens[-1].text,
+        text=(''.join(tk.text + tk.whitespace for tk in tokens[:-1]) + tokens[-1].text).strip(),
         tag=max(tokens, key=lambda tk: sum(1 if c == c.lower() else 2 for c in tk.text)).tag,
         whitespace=tokens[-1].whitespace,
         phonemes=phonemes,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-en = ["num2words", "spacy", "spacy-curated-transformers", "phonemizer-fork", "espeakng-loader", "torch", "transformers"]
+en = ["num2words", "spacy<4", "spacy-curated-transformers", "phonemizer-fork", "espeakng-loader", "torch", "transformers"]
 ja = ["fugashi", "jaconv", "mojimoji", "unidic", "pyopenjtalk"]
 ko = ["jamo", "nltk"]
 zh = ["jieba", "ordered-set", "pypinyin", "cn2an", "pypinyin-dict"]


### PR DESCRIPTION
## Summary
- Adds `local_files_only` parameter to `FallbackNetwork` and `G2P`
- Respects `TRANSFORMERS_OFFLINE` and `HF_HUB_OFFLINE` env vars
- Enables fully offline operation when models are pre-cached

## Problem
`FallbackNetwork.from_pretrained()` attempts network access even when `TRANSFORMERS_OFFLINE=1` is set, because `from_pretrained()` does a HEAD request to check for model updates before falling back to cache.

## Solution
Check the standard HuggingFace offline environment variables and pass `local_files_only=True` to `from_pretrained()` when they're set.

## Use case
- Air-gapped deployments
- Offline applications  
- Reducing startup latency when network is slow/unavailable

## Test
```python
import os
os.environ['TRANSFORMERS_OFFLINE'] = '1'
os.environ['HF_HUB_OFFLINE'] = '1'

from misaki import en
g2p = en.G2P()  # No network calls when model is cached
```

## Notes
- Backwards compatible: default behavior unchanged when env vars aren't set
- Can also be set explicitly: `G2P(local_files_only=True)`