### PR TITLE
Normalize curly apostrophes before POS tagging

### DIFF
--- a/misaki/en.py
+++ b/misaki/en.py
@@ -538,6 +538,9 @@ class G2P:
         features = {}
         last_end = 0
         text = text.lstrip()
+        # spaCy mis-tags a curly-apostrophe "n't" and the negation is lost, so
+        # normalize to a straight apostrophe before the text is tagged.
+        text = text.replace(chr(8216), "'").replace(chr(8217), "'")
         for m in LINK_REGEX.finditer(text):
             result += text[last_end:m.start()]
             tokens.extend(text[last_end:m.start()].split())


### PR DESCRIPTION
Fixes #100. Originally reported in hexgrad/kokoro#286.

A curly apostrophe (U+2019) in an `n't` contraction can cause spaCy to tag `n't` as punctuation instead of a negation, most reliably when the contraction is at the end of a clause. Misaki then drops that token, so the negation is lost.

Some examples I tested with:

```python
from misaki import en
g2p = en.G2P(british=False, fallback=None)

print(g2p("No, it wasn't.")[0])   # straight '  -> nˈO, ɪt wˈʌzᵊnt.
print(g2p("No, it wasn’t.")[0])   # curly U+2019 -> nˈO, ɪt wʌz.   ("wasn't" -> "was")
```

The Lexicon already normalizes these quotes in [` __call__`](https://github.com/hexgrad/misaki/blob/fba1236595f2d2bf21d414ba6e57d25256afada3/misaki/en.py#L478-L479), but that runs **after** tagging, so it can't influence the tag. This change normalizes curly single quotes to a straight apostrophe in [`preprocess`](https://github.com/hexgrad/misaki/blob/fba1236595f2d2bf21d414ba6e57d25256afada3/misaki/en.py#L535), before the text reaches spaCy, which gives the expected output in every case I tested.
